### PR TITLE
Unification of different callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,8 @@ if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
     # Show progress of FetchContent:
     set(FETCHCONTENT_QUIET OFF CACHE INTERNAL "" FORCE)
     FetchContent_Declare(curl
-                         GIT_REPOSITORY         https://github.com/curl/curl.git
-                         GIT_TAG                b81e0b07784dc4c1e8d0a86194b9d28776d071c0 # the hash for curl-7_69_1
-                         GIT_PROGRESS           TRUE
+                         URL                    https://github.com/curl/curl/releases/download/curl-7_69_1/curl-7.69.1.tar.xz
+                         URL_HASH               SHA256=03c7d5e6697f7b7e40ada1b2256e565a555657398e6c1fcfa4cb251ccd819d4f # the file hash for curl-7.69.1.tar.xz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
 
     FetchContent_MakeAvailable(curl)
@@ -124,9 +123,8 @@ if(BUILD_CPR_TESTS)
             set(gtest_force_shared_crt ON CACHE BOOL "Force gtest to use the shared c runtime")
         endif()
         FetchContent_Declare(googletest
-                             GIT_REPOSITORY         https://github.com/google/googletest.git
-                             GIT_TAG                703bd9caab50b139428cea1aaff9974ebee5742e # the hash for release-1.10.0
-                             GIT_PROGRESS           TRUE
+                             URL                    https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+                             URL_HASH               SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb # the file hash for release-1.10.0.tar.gz
                              USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
         FetchContent_MakeAvailable(googletest)
         
@@ -158,9 +156,8 @@ if(BUILD_CPR_TESTS)
     endif()
 
     FetchContent_Declare(mongoose 
-                         GIT_REPOSITORY         https://github.com/cesanta/mongoose.git
-                         GIT_TAG                80d74e9e341d541f71c0fa587d22cec89be32dd5 # the hash for 6.18
-                         GIT_PROGRESS           TRUE
+                         URL                    https://github.com/cesanta/mongoose/archive/6.18.tar.gz
+                         URL_HASH               SHA256=f5c10346abc9c72f7cac7885d853ca064fb09aad57580433941a8fd7a3543769 # the hash for 6.18.tar.gz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     # We can not use FetchContent_MakeAvailable, since we need to patch mongoose to use CMake
     if (NOT mongoose_POPULATED)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ C++ Requests currently supports:
 * Asynchronous requests
 * :cookie: support!
 * Proxy support
-* Callback interface
+* Callback interfaces
 * PUT methods
 * DELETE methods
 * HEAD methods
@@ -59,7 +59,6 @@ C++ Requests currently supports:
 * PATCH methods
 * Thread Safe access to [libCurl](https://curl.haxx.se/libcurl/c/threadsafe.html)
 * OpenSSL and WinSSL support for HTTPS requests
-* Progress callback support
 
 ## Planned
 

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(cpr
     auth.cpp
     cookies.cpp
     cprtypes.cpp
+    curl_container.cpp
     curlholder.cpp
     error.cpp
     multipart.cpp

--- a/cpr/curl_container.cpp
+++ b/cpr/curl_container.cpp
@@ -1,0 +1,62 @@
+#include "cpr/curl_container.h"
+
+
+namespace cpr {
+
+
+template<class T>
+CurlContainer<T>::CurlContainer(const std::initializer_list<T>& containerList) : containerList_(containerList) {
+
+}
+
+
+template<class T>
+void CurlContainer<T>::Add(const std::initializer_list<T>& containerList) {
+    for(const auto& element : containerList) {
+        containerList_.push_back(std::move(element));
+    }
+}
+
+template<class T>
+void CurlContainer<T>::Add(const T& element) {
+    containerList_.push_back(std::move(element));
+}
+
+template<>
+const std::string CurlContainer<Parameter>::GetContent(const CurlHolder& holder) const {
+    std::string content{};
+    for(const auto& parameter : containerList_) {
+        if (!content.empty()) {
+            content += "&";
+        }
+
+        std::string escapedKey = holder.urlEncode(parameter.key);
+        if (parameter.value.empty()) {
+            content += escapedKey;
+        } else {
+            std::string escapedValue = holder.urlEncode(parameter.value);
+            content += escapedKey + "=" + escapedValue;
+        }
+    };
+
+    return content;
+}
+
+template<>
+const std::string CurlContainer<Pair>::GetContent(const CurlHolder& holder) const {
+    std::string content{};
+    for(const auto& element : containerList_) {
+        if (!content.empty()) {
+            content += "&";
+        }
+        std::string escaped = holder.urlEncode(element.value);
+        content += element.key + "=" + escaped;
+    }
+
+    return content;
+}
+
+template class CurlContainer<Pair>;
+template class CurlContainer<Parameter>;
+
+} // namespace cpr

--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -7,7 +7,7 @@ std::mutex CurlHolder::curl_easy_init_mutex_{};
 CurlHolder::CurlHolder() {
     /**
      * Allow multithreaded access to CPR by locking curl_easy_init().
-     * curl_easy_init() is not thread save.
+     * curl_easy_init() is not thread safe.
      * References:
      * https://curl.haxx.se/libcurl/c/curl_easy_init.html
      * https://curl.haxx.se/libcurl/c/threadsafe.html

--- a/cpr/error.cpp
+++ b/cpr/error.cpp
@@ -28,6 +28,8 @@ ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
 #endif
         case CURLE_ABORTED_BY_CALLBACK:
             return ErrorCode::REQUEST_CANCELLED;
+        case CURLE_WRITE_ERROR:
+            return ErrorCode::REQUEST_CANCELLED;
         case CURLE_GOT_NOTHING:
             return ErrorCode::EMPTY_RESPONSE;
         case CURLE_SSL_ENGINE_NOTFOUND:

--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -7,32 +7,8 @@
 
 namespace cpr {
 
-Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
-    for (const auto& parameter : parameters) {
-        AddParameter(parameter, holder);
-    }
-}
+Parameters::Parameters(const std::initializer_list<Parameter>& parameters) : CurlContainer<Parameter>(parameters) {
 
-void Parameters::AddParameter(const Parameter& parameter) {
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
-    AddParameter(parameter, holder);
-}
-
-void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder) {
-    if (!content.empty()) {
-        content += "&";
-    }
-
-    std::string escapedKey = holder.urlEncode(parameter.key);
-    if (parameter.value.empty()) {
-        content += escapedKey;
-    } else {
-        std::string escapedValue = holder.urlEncode(parameter.value);
-        content += escapedKey + "=" + escapedValue;
-    }
 }
 
 } // namespace cpr

--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -15,6 +15,12 @@ Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
     }
 }
 
+void Parameters::AddParameter(const Parameter& parameter) {
+    // Create a temporary CurlHolder for URL encoding:
+    CurlHolder holder;
+    AddParameter(parameter, holder);
+}
+
 void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder) {
     if (!content.empty()) {
         content += "&";

--- a/cpr/payload.cpp
+++ b/cpr/payload.cpp
@@ -7,14 +7,8 @@
 
 namespace cpr {
 
-Payload::Payload(const std::initializer_list<Pair>& pairs) : Payload(begin(pairs), end(pairs)) {}
+Payload::Payload(const std::initializer_list<Pair>& pairs) : CurlContainer<Pair>(pairs) {
 
-void Payload::AddPair(const Pair& pair, const CurlHolder& holder) {
-    if (!content.empty()) {
-        content += "&";
-    }
-    std::string escaped = holder.urlEncode(pair.value);
-    content += pair.key + "=" + escaped;
 }
 
 } // namespace cpr

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -354,16 +354,20 @@ void Session::Impl::SetUnixSocket(const UnixSocket& unix_socket) {
 void Session::Impl::SetSslOptions(const SslOptions& opts) {
     CURL* curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_SSLCERT, opts.cert_file.c_str());
-        if (!opts.cert_type.empty()) {
-            curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, opts.cert_type.c_str());
+        if (!opts.cert_file.empty()) {
+            curl_easy_setopt(curl, CURLOPT_SSLCERT, opts.cert_file.c_str());
+            if (!opts.cert_type.empty()) {
+                curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, opts.cert_type.c_str());
+            }
         }
-        curl_easy_setopt(curl, CURLOPT_SSLKEY, opts.key_file.c_str());
-        if (!opts.key_type.empty()) {
-            curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, opts.key_type.c_str());
-        }
-        if (!opts.key_pass.empty()) {
-            curl_easy_setopt(curl, CURLOPT_KEYPASSWD, opts.key_pass.c_str());
+        if (!opts.key_file.empty()) {
+            curl_easy_setopt(curl, CURLOPT_SSLKEY, opts.key_file.c_str());
+            if (!opts.key_type.empty()) {
+                curl_easy_setopt(curl, CURLOPT_SSLKEYTYPE, opts.key_type.c_str());
+            }
+            if (!opts.key_pass.empty()) {
+                curl_easy_setopt(curl, CURLOPT_KEYPASSWD, opts.key_pass.c_str());
+            }
         }
 #if SUPPORT_ALPN
         curl_easy_setopt(curl, CURLOPT_SSL_ENABLE_ALPN, opts.enable_alpn ? ON : OFF);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -362,8 +362,8 @@ void Session::Impl::SetHeaderCallback(const HeaderCallback& header) {
     CURL* curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION , cpr::util::headerUserFunction);
-        curl_easy_setopt(curl, CURLOPT_HEADERDATA, &headercb_);
         headercb_ = header;
+        curl_easy_setopt(curl, CURLOPT_HEADERDATA, &headercb_);
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -345,6 +345,7 @@ void Session::Impl::SetBody(const Body& body) {
 void Session::Impl::SetReadCallback(const ReadCallback& read) {
     CURL* curl = curl_->handle;
     if (curl) {
+        readcb_ = read;
         curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE,
                          static_cast<curl_off_t>(read.size));
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
@@ -354,7 +355,6 @@ void Session::Impl::SetReadCallback(const ReadCallback& read) {
         if (read.size == -1) {
             SetHeader({{"Transfer-Encoding", "chunked"}});
         }
-        readcb_ = read;
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -379,6 +379,7 @@ void Session::Impl::SetWriteCallback(const WriteCallback& write) {
 void Session::Impl::SetProgressCallback(const ProgressCallback& progress) {
     CURL* curl = curl_->handle;
     if (curl) {
+        progresscb_ = progress;
         #if LIBCURL_VERSION_NUM < 0x072000
         curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, cpr::util::progressUserFunction);
         curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, &progresscb_);
@@ -387,7 +388,6 @@ void Session::Impl::SetProgressCallback(const ProgressCallback& progress) {
         curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &progresscb_);
         #endif
         curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-        progresscb_ = progress;
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -371,8 +371,8 @@ void Session::Impl::SetWriteCallback(const WriteCallback& write) {
     CURL* curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cpr::util::writeUserFunction);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writecb_);
         writecb_ = write;
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writecb_);
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -395,9 +395,9 @@ void Session::Impl::SetDebugCallback(const DebugCallback& debug) {
     CURL* curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, cpr::util::debugUserFunction);
+        debugcb_ = debug;
         curl_easy_setopt(curl, CURLOPT_DEBUGDATA, &debugcb_);
         curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-        debugcb_ = debug;
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -44,7 +44,7 @@ class Session::Impl {
     void SetReadCallback(const ReadCallback& read);
     void SetHeaderCallback(const HeaderCallback& header);
     void SetWriteCallback(const WriteCallback& write);
-    void SetProgressCallback(const ProgressCallback& parameters);
+    void SetProgressCallback(const ProgressCallback& progress);
     void SetDebugCallback(const DebugCallback& debug);
     void SetLowSpeed(const LowSpeed& low_speed);
     void SetVerifySsl(const VerifySsl& verify);

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -86,14 +86,45 @@ std::vector<std::string> split(const std::string& to_split, char delimiter) {
     return tokens;
 }
 
-size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* data) {
-    data->append(static_cast<char*>(ptr), size * nmemb);
-    return size * nmemb;
+size_t readUserFunction(char * ptr, size_t size, size_t nitems, const ReadCallback* read) {
+    size *= nitems;
+    return read->callback(ptr, size) ? size : CURL_READFUNC_ABORT;
 }
 
-size_t downloadFunction(void* ptr, size_t size, size_t nmemb, std::ofstream* file) {
-    file->write((char*) ptr, size * nmemb);
-    return size * nmemb;
+size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header) {
+    size *= nmemb;
+    return header->callback({ptr, size}) ? size : 0;
+}
+
+size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data)
+{
+    size *= nmemb;
+    data->append(ptr, size);
+    return size;
+}
+
+size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* file) {
+    size *= nmemb;
+    file->write(ptr, size);
+    return size;
+}
+
+size_t writeUserFunction(char * ptr, size_t size, size_t nmemb, const WriteCallback* write) {
+    size *= nmemb;
+    return write->callback({ptr, size}) ? size : 0;
+}
+
+#if LIBCURL_VERSION_NUM < 0x072000
+int progressUserFunction(const ProgressCallback * progress, double dltotal, double dlnow, double ultotal, double ulnow) {
+#else
+int progressUserFunction(const ProgressCallback * progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {
+#endif
+    return progress->callback(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
+}
+
+int debugUserFunction(CURL *handle, curl_infotype type, char * data, size_t size, const DebugCallback * debug) {
+    debug->callback(DebugCallback::InfoType(type), std::string(data, size));
+    return 0;
 }
 
 /**

--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -10,8 +10,8 @@ namespace cpr {
 class ReadCallback {
   public:
     ReadCallback() {}
-    ReadCallback(std::function<size_t(char* buffer, size_t & size)> callback) : size{-1}, callback{callback} {}
-    ReadCallback(ssize_t size, std::function<size_t(char* buffer, size_t & size)> callback) : size{size}, callback{callback} {}
+    ReadCallback(std::function<bool(char* buffer, size_t & size)> callback) : size{-1}, callback{callback} {}
+    ReadCallback(ssize_t size, std::function<bool(char* buffer, size_t & size)> callback) : size{size}, callback{callback} {}
 
     ssize_t size;
     std::function<bool(char* buffer, size_t & size)> callback;

--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -10,11 +10,13 @@ namespace cpr {
 class ReadCallback {
   public:
     ReadCallback() {}
-    ReadCallback(std::function<bool(char* buffer, size_t & size)> callback) : size{-1}, callback{callback} {}
-    ReadCallback(ssize_t size, std::function<bool(char* buffer, size_t & size)> callback) : size{size}, callback{callback} {}
+    ReadCallback(std::function<bool(char* buffer, size_t& size)> callback)
+            : size{-1}, callback{callback} {}
+    ReadCallback(cpr_off_t size, std::function<bool(char* buffer, size_t& size)> callback)
+            : size{size}, callback{callback} {}
 
-    ssize_t size;
-    std::function<bool(char* buffer, size_t & size)> callback;
+    cpr_off_t size;
+    std::function<bool(char* buffer, size_t& size)> callback;
 };
 
 class HeaderCallback {
@@ -36,24 +38,30 @@ class WriteCallback {
 class ProgressCallback {
   public:
     ProgressCallback() {}
-    ProgressCallback(std::function<bool(size_t downloadTotal, size_t downloadNow, size_t uploadTotal, size_t uploadNow)> callback) : callback(callback) {}
+    ProgressCallback(std::function<bool(size_t downloadTotal, size_t downloadNow,
+                                        size_t uploadTotal, size_t uploadNow)>
+                             callback)
+            : callback(callback) {}
 
-    std::function<bool(size_t downloadTotal, size_t downloadNow, size_t uploadTotal, size_t uploadNow)> callback;
+    std::function<bool(size_t downloadTotal, size_t downloadNow, size_t uploadTotal,
+                       size_t uploadNow)>
+            callback;
 };
 
 class DebugCallback {
   public:
     enum class InfoType {
-      TEXT = 0,
-      HEADER_IN = 1,
-      HEADER_OUT = 2,
-      DATA_IN = 3,
-      DATA_OUT = 4,
-      SSL_DATA_IN = 5,
-      SSL_DATA_OUT = 6,
+        TEXT = 0,
+        HEADER_IN = 1,
+        HEADER_OUT = 2,
+        DATA_IN = 3,
+        DATA_OUT = 4,
+        SSL_DATA_IN = 5,
+        SSL_DATA_OUT = 6,
     };
     DebugCallback() {}
-    DebugCallback(std::function<void(InfoType type, std::string data)> callback) : callback(callback) {}
+    DebugCallback(std::function<void(InfoType type, std::string data)> callback)
+            : callback(callback) {}
 
     std::function<void(InfoType type, std::string data)> callback;
 };

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -1,0 +1,54 @@
+#ifndef CURL_CONTAINER_H
+#define CURL_CONTAINER_H
+
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cpr/curlholder.h"
+
+
+namespace cpr {
+
+struct Parameter {
+    Parameter(const std::string& key, const std::string& value)
+            : key{key}, value{value} {}
+    Parameter(std::string&& key, std::string&& value)
+            : key{std::move(key)}, value{std::move(value)} {}
+
+    std::string key;
+    std::string value;
+};
+
+struct Pair {
+    Pair(const std::string& p_key, const std::string& p_value)
+            : key(p_key), value(p_value) {}
+    Pair(std::string&& p_key, std::string&& p_value)
+            : key(std::move(p_key)), value(std::move(p_value)) {}
+
+    std::string key;
+    std::string value;
+};
+
+
+template<class T>
+class CurlContainer {
+  public:
+    CurlContainer() = default;
+    CurlContainer(const std::initializer_list<T>&);
+
+  public:
+    void Add(const std::initializer_list<T>&);
+    void Add(const T&);
+
+  public:
+    const std::string GetContent(const CurlHolder&) const;
+
+  protected:
+    std::vector<T> containerList_;
+};
+
+} // namespace cpr
+
+#endif //

--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -4,31 +4,16 @@
 #include <initializer_list>
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "cpr/curlholder.h"
+#include "cpr/curl_container.h"
 
 namespace cpr {
 
-struct Parameter {
-    Parameter(const std::string& key, const std::string& value)
-            : key{key}, value{value} {}
-    Parameter(std::string&& key, std::string&& value)
-            : key{std::move(key)}, value{std::move(value)} {}
-
-    std::string key;
-    std::string value;
-};
-
-class Parameters {
+class Parameters : public CurlContainer<Parameter> {
   public:
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
-
-    void AddParameter(const Parameter& parameter);
-
-    void AddParameter(const Parameter& parameter, const CurlHolder& holder);
-
-    std::string content;
 };
 
 } // namespace cpr

--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -24,6 +24,8 @@ class Parameters {
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
 
+    void AddParameter(const Parameter& parameter);
+
     void AddParameter(const Parameter& parameter, const CurlHolder& holder);
 
     std::string content;

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -6,36 +6,21 @@
 #include <memory>
 #include <string>
 
-#include "cpr/curlholder.h"
+#include "cpr/curl_container.h"
 #include <utility>
 
 namespace cpr {
 
-struct Pair {
-    Pair(const std::string& p_key, const std::string& p_value)
-            : key(p_key), value(p_value) {}
-    Pair(std::string&& p_key, std::string&& p_value)
-            : key(std::move(p_key)), value(std::move(p_value)) {}
 
-    std::string key;
-    std::string value;
-};
-
-class Payload {
+class Payload : public CurlContainer<Pair> {
   public:
     template <class It>
     Payload(const It begin, const It end) {
-        // Create a temporary CurlHolder for URL encoding:
-        CurlHolder holder;
         for (It pair = begin; pair != end; ++pair) {
-            AddPair(*pair, holder);
+            Add(*pair);
         }
     }
     Payload(const std::initializer_list<Pair>& pairs);
-
-    void AddPair(const Pair& pair, const CurlHolder& holder);
-
-    std::string content;
 };
 
 } // namespace cpr

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -37,9 +37,6 @@ class Session {
     Session(Session&& other);
     Session& operator=(Session&& other);
 
-    void SetReadCallback(const ReadCallback& read);
-    void SetWriteCallback(const WriteCallback& write);
-    void SetProgressCallback(const ProgressCallback& progress);
     void SetUrl(const Url& url);
     void SetParameters(const Parameters& parameters);
     void SetParameters(Parameters&& parameters);
@@ -65,12 +62,14 @@ class Session {
     void SetVerifySsl(const VerifySsl& verify);
     void SetUnixSocket(const UnixSocket& unix_socket);
     void SetSslOptions(const SslOptions& options);
+    void SetReadCallback(const ReadCallback& read);
+    void SetHeaderCallback(const HeaderCallback& header);
+    void SetWriteCallback(const WriteCallback& write);
+    void SetProgressCallback(const ProgressCallback& progress);
+    void SetDebugCallback(const DebugCallback& debug);
     void SetVerbose(const Verbose& verbose);
 
     // Used in templated functions
-    void SetOption(const ReadCallback& read);
-    void SetOption(const WriteCallback& write);
-    void SetOption(const ProgressCallback& progress);
     void SetOption(const Url& url);
     void SetOption(const Parameters& parameters);
     void SetOption(Parameters&& parameters);
@@ -93,6 +92,11 @@ class Session {
     void SetOption(const Cookies& cookies);
     void SetOption(Body&& body);
     void SetOption(const Body& body);
+    void SetOption(const ReadCallback& read);
+    void SetOption(const HeaderCallback& header);
+    void SetOption(const WriteCallback& write);
+    void SetOption(const ProgressCallback& progress);
+    void SetOption(const DebugCallback& debug);
     void SetOption(const LowSpeed& low_speed);
     void SetOption(const VerifySsl& verify);
     void SetOption(const Verbose& verbose);

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "cpr/callback.h"
 #include "cpr/cookies.h"
 #include "cpr/cprtypes.h"
 #include "cpr/curlholder.h"
@@ -15,8 +16,17 @@ namespace util {
 Header parseHeader(const std::string& headers, std::string* status_line = nullptr,
                    std::string* reason = nullptr);
 Cookies parseCookies(curl_slist* raw_cookies);
-size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* data);
-size_t downloadFunction(void* ptr, size_t size, size_t nmemb, std::ofstream* file);
+size_t readUserFunction(char * ptr, size_t size, size_t nitems, const ReadCallback* read);
+size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header);
+size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data);
+size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* write);
+size_t writeUserFunction(char * ptr, size_t size, size_t nmemb, const WriteCallback* write);
+#if LIBCURL_VERSION_NUM < 0x072000
+int progressUserFunction(const ProgressCallback * progress, double dltotal, double dlnow, double ultotal, double ulnow);
+#else
+int progressUserFunction(const ProgressCallback * progress, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
+#endif
+int debugUserFunction(CURL *handle, curl_infotype type, char * data, size_t size, const DebugCallback * debug);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
 

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -173,8 +173,8 @@ TEST(ParameterTests, MultipleDynamicParametersTest) {
     Parameters parameters{{"key", "value"}};
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
-    parameters.AddParameter({"hello", "world"}, holder);
-    parameters.AddParameter({"test", "case"});
+    parameters.Add({"hello", "world"});
+    parameters.Add({"test", "case"});
     Response response = cpr::Get(url, parameters);
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -174,7 +174,7 @@ TEST(ParameterTests, MultipleDynamicParametersTest) {
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
     parameters.AddParameter({"hello", "world"}, holder);
-    parameters.AddParameter({"test", "case"}, holder);
+    parameters.AddParameter({"test", "case"});
     Response response = cpr::Get(url, parameters);
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -171,8 +171,6 @@ TEST(ParameterTests, MultipleParametersTest) {
 TEST(ParameterTests, MultipleDynamicParametersTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Parameters parameters{{"key", "value"}};
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
     parameters.Add({"hello", "world"});
     parameters.Add({"test", "case"});
     Response response = cpr::Get(url, parameters);

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -33,7 +33,7 @@ TEST(UrlEncodedPostTests, UrlPostAddPayloadPair) {
     Payload payload{{"x", "1"}};
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
-    payload.AddPair({"y", "2"}, holder);
+    payload.Add({"y", "2"});
     Response response = cpr::Post(url, payload);
     std::string expected_text{
             "{\n"

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -31,8 +31,6 @@ TEST(UrlEncodedPostTests, UrlPostSingleTest) {
 TEST(UrlEncodedPostTests, UrlPostAddPayloadPair) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Payload payload{{"x", "1"}};
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
     payload.Add({"y", "2"});
     Response response = cpr::Post(url, payload);
     std::string expected_text{

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -13,7 +13,7 @@ TEST(PayloadTests, UseStringVariableTest) {
     Payload payload {{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(payload.content, expected);
+    EXPECT_EQ(payload.GetContent(CurlHolder()), expected);
 }
 
 TEST(ParametersTests, UseStringVariableTest) {
@@ -22,7 +22,7 @@ TEST(ParametersTests, UseStringVariableTest) {
     Parameters parameters {{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(parameters.content, expected);
+    EXPECT_EQ(parameters.GetContent(CurlHolder()), expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Working off the incredibly helpful existing design, I merged with master, massaged the disparate parts of the code into something new using std:function and whatever design preferences I happened to be recently familiar with, and added basic tests.

I put the static callback implementations into cpr::util and gave the others already there more consistent naming.

I moved where the implementations were in the session code downwards in the file, since they are advanced features, less important to see early.

I ran into some duplicated code and replaced it with reuse because paying attention to things can be hard for me and I usually forget to update and test both instances of duplicated code.  This choice appears inconsistent with the rest of the codebase, unfortunately, but is harmless.

I also added debug callbacks because I ran into the curl debug callback feature during the work.

The implementation continues existing possible concerns around whether the Response object properties should be filled if callbacks are provided.  At the moment they are not because that seemed easier to implement and document at first, to me.

I didn't review the rest of the codebase to see how in line the work is with existing design, but all 4 callbacks pass tests now.  Returning false from the callbacks cancels the transaction.  See https://github.com/ITotalJustice/cpr/commit/f6473f814d5622bc5012110e8420bc3bdbc87f93 to separate my changes from the merge changes.